### PR TITLE
🐛 fix: Correctly build edit URL for docs

### DIFF
--- a/src/components/02_molecules/editOnGithub/EditOnGithub.tsx
+++ b/src/components/02_molecules/editOnGithub/EditOnGithub.tsx
@@ -7,9 +7,9 @@ export interface EditOnGithubProps {
 }
 
 export const EditOnGithub: React.FC<EditOnGithubProps> = ({ file }) => {
-  const url = path.join(
-    "https://github.com/porscheofficial/porscheofficial.github.io/edit/main/",
-    file
+  const url = new URL(
+    path.join("porscheofficial/porscheofficial.github.io/edit/main/", file),
+    "https://github.com/"
   );
   return (
     <div className={s["editOnGithub-container"]}>

--- a/src/components/02_molecules/editOnGithub/EditOnGithub.tsx
+++ b/src/components/02_molecules/editOnGithub/EditOnGithub.tsx
@@ -15,7 +15,7 @@ export const EditOnGithub: React.FC<EditOnGithubProps> = ({ file }) => {
     <div className={s["editOnGithub-container"]}>
       <LinkButton
         className={s.editOnGithub}
-        href={url}
+        href={url.href}
         variant="secondary"
         iconSource="/assets/octicons/mark-github.svg"
         theme="dark"


### PR DESCRIPTION
## 📑 Description
The URL for the "Edit on GitHub" button is not correctly constructed. This PR introduces a fix that makes use of the native `URL` constructor.

## ✅ Checks
- [X] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)
