### PR TITLE
♻️ Use PTag with light theme for FOSS principles

### DIFF
--- a/src/components/02_molecules/foss_movement/Principle.tsx
+++ b/src/components/02_molecules/foss_movement/Principle.tsx
@@ -2,6 +2,7 @@
 import { PropsWithChildren, ReactNode } from "react";
 import s from "./principle.module.scss";
 import { Text } from "../../01_atoms/Text";
+import { Tag } from "../../01_atoms/Tag";
 
 export interface PrincipleProps {
   hashtag: string;
@@ -14,7 +15,9 @@ export const Principle: React.FC<PropsWithChildren<PrincipleProps>> = (
   const { hashtag, children } = props;
   return (
     <div className={s.principle}>
-      <span className={s.hashtag}>#{hashtag}</span>
+      <Tag className={s.hashtag} theme="light">
+        #{hashtag}
+      </Tag>
       <Text size="medium" theme="dark">
         {children}
       </Text>

--- a/src/components/02_molecules/foss_movement/principle.module.scss
+++ b/src/components/02_molecules/foss_movement/principle.module.scss
@@ -19,11 +19,5 @@
 }
 
 .hashtag {
-  @include pds-text-x-small;
-  display: inline-block;
   margin-bottom: $pds-spacing-fluid-small;
-  padding: 4px 9px;
-  border-radius: $pds-border-radius-small;
-  background-color: $pds-theme-light-background-surface;
-  color: $pds-theme-light-primary;
 }


### PR DESCRIPTION
## 📑 Description
This PR removes the self-built hashtag element and instead uses the PTag component from https://github.com/porsche-design-system/porsche-design-system with light theme. Kudos to @stephanschroeter for raising this issue.

## ✅ Checks
- [X] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)
