### PR TITLE
🚨 fix warning: Use <a> within PText

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,6 @@ import { Section } from "../components/02_molecules/section/section";
 import { Projects, News, Memberships } from "../types/general";
 import { Membership } from "../components/03_organisms/membership/Membership";
 import { Heading } from "../components/01_atoms/Heading";
-import { LinkPure } from "../components/01_atoms/LinkPure";
 
 const Home: React.FC = () => {
   const projects: Projects = importProjects as Projects;
@@ -91,19 +90,9 @@ const Home: React.FC = () => {
         </Heading>
         <Textblock className={s.text}>
           <Text theme="dark" size="medium" align="center">
-            Our{" "}
-            <LinkPure
-              theme="dark"
-              underline
-              icon="none"
-              size="medium"
-              href="/docs"
-            >
-              growing documentation
-            </LinkPure>{" "}
-            provides transparency on how Porsche is contributing to open source
-            and the standards we are endorsing for new projects to foster
-            healthy communities.
+            Our <a href="/docs">growing documentation</a> provides transparency
+            on how Porsche is contributing to open source and the standards we
+            are endorsing for new projects to foster healthy communities.
           </Text>
         </Textblock>
       </Section>


### PR DESCRIPTION
## 📑 Description
PDS warns to not use PLinkPure within PText. This PR switches to a pure <a> tag within the PText component.

## ✅ Checks
- [X] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)
