### PR TITLE
📝 Add reference to latest Newsroom article

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@primer/octicons": "19.3.0",
     "classnames": "2.3.2",
     "next": "13.4.6",
-    "next-image-export-optimizer": "1.7.0",
+    "next-image-export-optimizer": "1.8.4",
     "prism-react-renderer": "2.0.5",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/remoteOptimizedImages.js
+++ b/remoteOptimizedImages.js
@@ -6,4 +6,5 @@ module.exports = [
   "https://eslint.org/icon-512.png",
   "https://developer.android.com/static/images/brand/Android_Robot.png",
   "https://raw.githubusercontent.com/mbeddr/mbeddr.core/master/logos/2013/blue_orange/LogoBigTransparent.png",
+  "https://newsroom.porsche.com/.imaging/mte/porsche-templating-theme/image_690x388/dam/pnr/other/executive-board/Meschke/pictures-NEW/New/Meschke1.jpg/jcr:content/Meschke1.jpg"
 ];

--- a/remoteOptimizedImages.js
+++ b/remoteOptimizedImages.js
@@ -6,5 +6,5 @@ module.exports = [
   "https://eslint.org/icon-512.png",
   "https://developer.android.com/static/images/brand/Android_Robot.png",
   "https://raw.githubusercontent.com/mbeddr/mbeddr.core/master/logos/2013/blue_orange/LogoBigTransparent.png",
-  "https://newsroom.porsche.com/.imaging/mte/porsche-templating-theme/image_690x388/dam/pnr/other/executive-board/Meschke/pictures-NEW/New/Meschke1.jpg/jcr:content/Meschke1.jpg"
+  "https://newsroom.porsche.com/.imaging/mte/porsche-templating-theme/image_690x388/dam/pnr/other/executive-board/Meschke/pictures-NEW/New/Meschke1.jpg/jcr:content/Meschke1.jpg",
 ];

--- a/src/data/news.yml
+++ b/src/data/news.yml
@@ -1,5 +1,10 @@
 heading: News & Media
 items:
+  - title: |
+      FOSS Movement: Porsche accelerates open source initiative with board member support
+    url: https://newsroom.porsche.com/en/2023/company/porsche-foss-movements-open-source-software-strategy-33413.html
+    imageSrc: https://newsroom.porsche.com/.imaging/mte/porsche-templating-theme/image_690x388/dam/pnr/other/executive-board/Meschke/pictures-NEW/New/Meschke1.jpg/jcr:content/Meschke1.jpg
+    imageAlt: Lutz Meschke, Deputy Chairman of the Executive Board and Member of the Executive Board for Finance and IT at Porsche AG, 2019, Porsche AG
   - title: The Porsche OSPO Journey
     url: https://todogroup.org/guides/casestudies/porsche/
     imageSrc: /assets/cover4.jpg

--- a/yarn.lock
+++ b/yarn.lock
@@ -4069,9 +4069,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next-image-export-optimizer@npm:1.7.0":
-  version: 1.7.0
-  resolution: "next-image-export-optimizer@npm:1.7.0"
+"next-image-export-optimizer@npm:1.8.4":
+  version: 1.8.4
+  resolution: "next-image-export-optimizer@npm:1.8.4"
   dependencies:
     cli-progress: ^3.10.0
     sharp: ^0.32.0
@@ -4081,7 +4081,7 @@ __metadata:
     react: ^18.0.0-0
   bin:
     next-image-export-optimizer: dist/optimizeImages.js
-  checksum: 9bcff3a1c68468f8b1cdd1e2e22d5d2c3fb9dd52d512f00cc88749318380fe67df52c6eff63f5dc6cecfd080f46f6b105c864d99d0ad8cd48d1ef0400892157d
+  checksum: b5de229321c2ab09c044e643f1e325b74f67424e97f8abdcb4d72c9e4cc44b050dedccd5cba529ff165bb2560379785cec0692cb6c9dfe824df551af43b9e8af
   languageName: node
   linkType: hard
 
@@ -4490,7 +4490,7 @@ __metadata:
     http-server: 14.1.1
     js-yaml-loader: 1.2.2
     next: 13.4.6
-    next-image-export-optimizer: 1.7.0
+    next-image-export-optimizer: 1.8.4
     prettier: 2.8.8
     prism-react-renderer: 2.0.5
     react: 18.2.0


### PR DESCRIPTION
This commit also bumps next-image-export-optimizer to 1.8.4. Kudos to @Niels-IO for providing a fix for a problem we encountered with the article's preview image.

## ✅ Checks
- [X] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)
