### PR TITLE
Replace contact button with link to GitHub profile

### DIFF
--- a/src/components/02_molecules/footer/Footer.tsx
+++ b/src/components/02_molecules/footer/Footer.tsx
@@ -118,10 +118,10 @@ export const Footer: React.FC = () => {
       </div>
       <div className={s.middle}>
         <PText size="large" theme="dark">
-          GitHub
+          Open Source
         </PText>
         <div className={s.content}>
-          <PText theme="dark">See all open-source projects by Porsche.</PText>
+          <PText theme="dark">Find us on GitHub.</PText>
           <PLink
             href="https://github.com/porscheofficial"
             theme="dark"


### PR DESCRIPTION
## 📑 Description
This PR replaces the current "Contact us" button in the page's footer with a link to our GitHub profile.

## ✅ Checks
- [X] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)
