### PR TITLE
csp and anti clickjacking policy |js/fw |

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -72,14 +72,14 @@ const cspHeader = `
 const RootLayout: React.FC<React.PropsWithChildren> = ({ children }) => {
   return (
     <html lang="en">
-    <head>
-      <meta
-        httpEquiv="Content-Security-Policy"
-        content={cspHeader.replace(/\n/g, "")}
-      />
-      <style id="antiClickjack">{"body{display:none !important;}"}</style>
-      <Script id="antiClickjackScript">
-        {`
+      <head>
+        <meta
+          httpEquiv="Content-Security-Policy"
+          content={cspHeader.replace(/\n/g, "")}
+        />
+        <style id="antiClickjack">{"body{display:none !important;}"}</style>
+        <Script id="antiClickjackScript">
+          {`
             if (self === top) {
               var antiClickjack = document.getElementById("antiClickjack");
               antiClickjack.parentNode.removeChild(antiClickjack);
@@ -87,7 +87,7 @@ const RootLayout: React.FC<React.PropsWithChildren> = ({ children }) => {
               top.location = self.location;
             }
         `}
-      </Script>
+        </Script>
         {/* necessary for SSR support, injects stylesheet which defines visibility of pre-hydrated PDS components */}
         {getInitialStyles({ format: "jsx" })}
         {/* injects stylesheet which defines Porsche Next CSS font-face definition (=> minimize FOUT) */}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import Script from "next/script";
 import {
   getInitialStyles,
   getFontFaceStylesheet,
@@ -56,10 +57,37 @@ export const metadata: Metadata = {
   },
 };
 
+const cspHeader = `
+    default-src 'self' https://api.github.com/repos/;
+    script-src 'self' 'unsafe-eval' 'unsafe-inline' https://cdn.ui.porsche.com/porsche-design-system/;
+    style-src 'self' 'unsafe-inline' https://cdn.ui.porsche.com/porsche-design-system/;
+    img-src 'self' blob: data: https://cdn.ui.porsche.com/porsche-design-system/ https://raw.githubusercontent.com/porscheofficial/cookie-consent-banner/;
+    font-src 'self' https://cdn.ui.porsche.com/porsche-design-system/;
+    object-src 'none';
+    manifest-src 'self' https://cdn.ui.porsche.com/porsche-design-system/;
+    base-uri 'self';
+    form-action 'self';
+    upgrade-insecure-requests;
+    `;
 const RootLayout: React.FC<React.PropsWithChildren> = ({ children }) => {
   return (
     <html lang="en">
-      <head>
+    <head>
+      <meta
+        httpEquiv="Content-Security-Policy"
+        content={cspHeader.replace(/\n/g, "")}
+      />
+      <style id="antiClickjack">{"body{display:none !important;}"}</style>
+      <Script id="antiClickjackScript">
+        {`
+            if (self === top) {
+              var antiClickjack = document.getElementById("antiClickjack");
+              antiClickjack.parentNode.removeChild(antiClickjack);
+            } else {
+              top.location = self.location;
+            }
+        `}
+      </Script>
         {/* necessary for SSR support, injects stylesheet which defines visibility of pre-hydrated PDS components */}
         {getInitialStyles({ format: "jsx" })}
         {/* injects stylesheet which defines Porsche Next CSS font-face definition (=> minimize FOUT) */}


### PR DESCRIPTION
## 📑 Description
Add a content security policy for this static web page and anti clickjacking based on https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html#defending-with-samesite-cookies since frame-ancestors in not supported in page headers meta tags
## ✅ Checks
- [x] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)
